### PR TITLE
Std futures and async/await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["networking", "snmp", "monitoring"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.1", optional = true }
-tokio-udp = { version = "0.1", optional = true }
-futures = { version = "0.1", optional = true }
-bytes = "0.4"
+tokio = { version = "0.2.4", features = ["udp", "time"], optional = true }
+
+[dev-dependencies]
+tokio = { version = "0.2.4", features = ["udp", "time", "macros"] }
 
 [features]
 default = ["async"]
-async = ["tokio", "tokio-udp", "futures"]
+async = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 tokio = { version = "0.2.4", features = ["udp", "time"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "0.2.4", features = ["udp", "time", "macros"] }
+tokio = { version = "0.2.4", features = ["udp", "time", "macros", "rt-threaded"] }
 
 [features]
 default = ["async"]

--- a/examples/async-get.rs
+++ b/examples/async-get.rs
@@ -4,7 +4,8 @@ use tokio;
 
 use snmp::{AsyncSession, Value};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     if let Some(param) = env::args().nth(1) {
         let sys_descr_oid = &[1, 3, 6, 1, 2, 1, 1, 1, 0];
         let agent_addr = format!("{}:161", param);
@@ -14,7 +15,7 @@ fn main() {
         let mut session = AsyncSession::new(&agent_addr, community, Some(timeout), 0).unwrap();
 
         let mut response =
-            tokio::runtime::current_thread::block_on_all(session.get(sys_descr_oid)).unwrap();
+            session.get(sys_descr_oid).await.unwrap();
 
         if let Some((_oid, Value::OctetString(sys_descr))) = response.varbinds.next() {
             println!("sysDescr: {}", String::from_utf8_lossy(&sys_descr));

--- a/examples/async-get.rs
+++ b/examples/async-get.rs
@@ -1,7 +1,5 @@
 use std::{env, time::Duration};
 
-use tokio;
-
 use snmp::{AsyncSession, Value};
 
 #[tokio::main]

--- a/src/async.rs
+++ b/src/async.rs
@@ -15,7 +15,7 @@ struct AsyncRequest {
 }
 
 impl AsyncRequest {
-    async fn send_and_recv(mut self, pdu: pdu::Buf) -> SnmpResult<Vec<u8>> {
+    async fn send_and_recv(&mut self, pdu: pdu::Buf) -> SnmpResult<Vec<u8>> {
         use tokio::time;
 
         self.socket
@@ -93,7 +93,7 @@ impl AsyncSession {
     async fn send_and_recv(&self, pdu: pdu::Buf) -> SnmpResult<Vec<u8>> {
         match self.new_socket().await {
             Ok(socket) => {
-                let req = AsyncRequest {
+                let mut req = AsyncRequest {
                     socket,
                     timeout: self.timeout,
                 };
@@ -166,7 +166,7 @@ impl AsyncSession {
     ///   - `Timeticks`
     ///   - `Opaque`
     ///   - `Counter64`
-    pub async fn set(mut self, values: &[(&[u32], Value)]) -> SnmpResult<SnmpPdu> {
+    pub async fn set(&mut self, values: &[(&[u32], Value)]) -> SnmpResult<SnmpPdu> {
         let req_id = self.req_id.0;
 
         let mut send_pdu = pdu::Buf::default();

--- a/src/async.rs
+++ b/src/async.rs
@@ -5,49 +5,48 @@ use std::{
     time::Duration,
 };
 
-use bytes::Bytes;
-use futures::{Future, IntoFuture};
-use tokio::{net::UdpSocket, util::FutureExt};
+use tokio::net::UdpSocket;
 
-use crate::{handle_response, pdu, SnmpError, SnmpMessageType, SnmpPdu, Value, BUFFER_SIZE};
-
-type SnmpFuture<T> = Box<Future<Item = T, Error = SnmpError> + Send>;
+use crate::{handle_response, pdu, SnmpError, SnmpResult, SnmpMessageType, SnmpPdu, Value, BUFFER_SIZE};
 
 struct AsyncRequest {
     socket: UdpSocket,
-    destination: SocketAddr,
     timeout: Option<Duration>,
 }
 
 impl AsyncRequest {
-    fn send_and_recv(self, pdu: pdu::Buf) -> SnmpFuture<Bytes> {
-        let fut = self
-            .socket
-            .send_dgram(Bytes::from(&pdu[..]), &self.destination)
-            .map_err(|_| SnmpError::SendError);
+    async fn send_and_recv(mut self, pdu: pdu::Buf) -> SnmpResult<Vec<u8>> {
+        use tokio::time;
+
+        self.socket
+            .send(&pdu[..])
+            .await
+            .map_err(|_| SnmpError::SendError)?;
+
+        let mut buf = [0; BUFFER_SIZE];
+
+        let fut = self.socket
+            .recv(&mut buf);
 
         match self.timeout {
-            Some(timeout) => Box::new(fut.and_then(move |(socket, _)| {
-                socket
-                    .recv_dgram(vec![0; BUFFER_SIZE])
-                    .timeout(timeout)
-                    .map_err(|_| SnmpError::ReceiveError)
-                    .and_then(|(_socket, buf, size, _addr)| Ok(buf[0..size].into()))
-            })),
-            None => Box::new(fut.and_then(|(socket, _)| {
-                socket
-                    .recv_dgram(vec![0; BUFFER_SIZE])
-                    .map_err(|_| SnmpError::ReceiveError)
-                    .and_then(|(_socket, buf, size, _addr)| Ok(buf[0..size].into()))
-            })),
+            Some(timeout) => {
+                time::timeout(timeout, fut)
+                .await
+                .map_err(|_| SnmpError::ReceiveError)?
+            },
+            None => {
+                fut.await
+            },
         }
+            .map_err(|_| SnmpError::ReceiveError)
+            .map(|size| buf[0..size].into())
     }
 }
 
 /// Asynchronous SNMPv2 client.
 pub struct AsyncSession {
     destination: SocketAddr,
-    community: Bytes,
+    community: Vec<u8>,
     timeout: Option<Duration>,
     req_id: Wrapping<i32>,
 }
@@ -76,33 +75,35 @@ impl AsyncSession {
         })
     }
 
-    fn new_socket(&self) -> io::Result<UdpSocket> {
-        let addr_to_bind = if self.destination.ip().is_ipv4() {
+    async fn new_socket(&self) -> io::Result<UdpSocket> {
+        let addr_to_bind: SocketAddr = if self.destination.ip().is_ipv4() {
             "0.0.0.0:0".parse().unwrap()
         } else {
             "[::]:0".parse().unwrap()
         };
-        UdpSocket::bind(&addr_to_bind).and_then(|socket| {
-            socket.connect(&self.destination)?;
-            Ok(socket)
-        })
+
+        let socket = UdpSocket::bind(&addr_to_bind)
+            .await?;
+        socket
+            .connect(&self.destination)
+            .await?;
+        Ok(socket)
     }
 
-    fn send_and_recv(&self, pdu: pdu::Buf) -> SnmpFuture<Bytes> {
-        match self.new_socket() {
+    async fn send_and_recv(&self, pdu: pdu::Buf) -> SnmpResult<Vec<u8>> {
+        match self.new_socket().await {
             Ok(socket) => {
                 let req = AsyncRequest {
                     socket,
-                    destination: self.destination,
                     timeout: self.timeout,
                 };
-                req.send_and_recv(pdu)
+                req.send_and_recv(pdu).await
             }
-            Err(_) => Box::new(Err(SnmpError::SocketError).into_future()),
+            Err(_) => Err(SnmpError::SocketError),
         }
     }
 
-    pub fn get(&mut self, name: &[u32]) -> SnmpFuture<SnmpPdu> {
+    pub async fn get(&mut self, name: &[u32]) -> SnmpResult<SnmpPdu> {
         let req_id = self.req_id.0;
 
         let mut send_pdu = pdu::Buf::default();
@@ -111,13 +112,11 @@ impl AsyncSession {
         self.req_id += Wrapping(1);
 
         let community = self.community.clone();
-        Box::new(
-            self.send_and_recv(send_pdu)
-                .and_then(move |buf| handle_response(req_id, &community, buf.into())),
-        )
+        let response = self.send_and_recv(send_pdu).await?;
+        handle_response(req_id, &community, response)
     }
 
-    pub fn getnext(&mut self, name: &[u32]) -> SnmpFuture<SnmpPdu> {
+    pub async fn getnext(&mut self, name: &[u32]) -> SnmpResult<SnmpPdu> {
         let req_id = self.req_id.0;
 
         let mut send_pdu = pdu::Buf::default();
@@ -126,18 +125,15 @@ impl AsyncSession {
         self.req_id += Wrapping(1);
 
         let community = self.community.clone();
-        Box::new(
-            self.send_and_recv(send_pdu)
-                .and_then(move |buf| handle_response(req_id, &community, buf.into())),
-        )
+        let buf = self.send_and_recv(send_pdu).await?;
+        handle_response(req_id, &community, buf.into())
     }
-
-    pub fn getbulk(
+    pub async fn getbulk(
         &mut self,
         names: &[&[u32]],
         non_repeaters: u32,
         max_repetitions: u32,
-    ) -> SnmpFuture<SnmpPdu> {
+    ) -> SnmpResult<SnmpPdu> {
         let req_id = self.req_id.0;
 
         let mut send_pdu = pdu::Buf::default();
@@ -153,10 +149,9 @@ impl AsyncSession {
         self.req_id += Wrapping(1);
 
         let community = self.community.clone();
-        Box::new(
-            self.send_and_recv(send_pdu)
-                .and_then(move |buf| handle_response(req_id, &community, buf.into())),
-        )
+
+        let buf = self.send_and_recv(send_pdu).await?;
+        handle_response(req_id, &community, buf.into())
     }
 
     /// # Panics if any of the values are not one of these supported types:
@@ -171,7 +166,7 @@ impl AsyncSession {
     ///   - `Timeticks`
     ///   - `Opaque`
     ///   - `Counter64`
-    pub fn set(mut self, values: &[(&[u32], Value)]) -> SnmpFuture<SnmpPdu> {
+    pub async fn set(mut self, values: &[(&[u32], Value)]) -> SnmpResult<SnmpPdu> {
         let req_id = self.req_id.0;
 
         let mut send_pdu = pdu::Buf::default();
@@ -180,18 +175,17 @@ impl AsyncSession {
         self.req_id += Wrapping(1);
 
         let community = self.community.clone();
-        Box::new(self.send_and_recv(send_pdu).and_then(move |buf| {
-            let resp = SnmpPdu::from_bytes(&buf)?;
+        let buf = self.send_and_recv(send_pdu).await?;
+        let resp = SnmpPdu::from_bytes(&buf)?;
 
-            if resp.message_type != SnmpMessageType::Response {
-                Err(SnmpError::AsnWrongType)
-            } else if resp.req_id != req_id {
-                Err(SnmpError::RequestIdMismatch)
-            } else if resp.community != community {
-                Err(SnmpError::CommunityMismatch)
-            } else {
-                Ok(resp)
-            }
-        }))
+        if resp.message_type != SnmpMessageType::Response {
+            Err(SnmpError::AsnWrongType)
+        } else if resp.req_id != req_id {
+            Err(SnmpError::RequestIdMismatch)
+        } else if resp.community != community {
+            Err(SnmpError::CommunityMismatch)
+        } else {
+            Ok(resp)
+        }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -48,7 +48,7 @@ fn asn_parse_getnext_pdu() {
             let version = rdr.read_asn_integer()?;
             assert_eq!(version, snmp::VERSION_2 as i64);
             let community = rdr.read_asn_octetstring()?;
-            assert_eq!(community.as_ref(), b"tyS0n43d");
+            assert_eq!(&community, b"tyS0n43d");
             println!("version: {}", version);
             let msg_ident = rdr.peek_byte()?;
             println!("msg_ident: {}", msg_ident);


### PR DESCRIPTION
I have updated to use std futures, tokio 0.2 and async/await.

I also replaced uses of `uninitialized()` with `[0; SIZE];` and removed `Bytes` dependency, please tell me if I should undo any of that.