### PR TITLE
Make SnmpPdu::community public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1209,7 +1209,7 @@ fn handle_response(req_id: i32, community: &[u8], response: Vec<u8>) -> SnmpResu
 #[derive(Debug)]
 pub struct SnmpPdu {
     version: i64,
-    community: Vec<u8>,
+    pub community: Vec<u8>,
     pub message_type: SnmpMessageType,
     pub req_id: i32,
     pub error_status: u32,


### PR DESCRIPTION
I was trying to implement a simple trap receiver that only collects traps with whitelisted communities. Turned out to be hard without access to the community :)

Is there any reason not to make `SnmpPdu::community` public?